### PR TITLE
Rename CREDIT to CRediT

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,8 +9,8 @@ import { Footer } from '@/components/Footer'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Credit Maker',
-  description: 'Create CREDIT statements easily',
+  title: 'CRediT Maker',
+  description: 'Create CRediT statements easily',
 }
 
 export default function RootLayout({

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,7 +11,7 @@ export function Header() {
         </div>
 
         <div className='mx-auto flex items-center border-b border-blue-600/10'>
-          <p className='font-mono text-2xl text-blue-600'>CREDIT Maker</p>
+          <p className='font-mono text-2xl text-blue-600'>CRediT Maker</p>
         </div>
 
         <div className='hidden grow basis-0 justify-end sm:flex'>


### PR DESCRIPTION
I would use the "official" spelling: https://credit.niso.org